### PR TITLE
fix: convert CreateSpeakersCallFragment to a proper fragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/create/CreateSpeakersCallFragment.java
@@ -12,7 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import org.fossasia.openevent.app.R;
-import org.fossasia.openevent.app.common.mvp.view.BaseBottomSheetFragment;
+import org.fossasia.openevent.app.common.mvp.view.BaseFragment;
 import org.fossasia.openevent.app.core.main.MainActivity;
 import org.fossasia.openevent.app.data.speakerscall.SpeakersCall;
 import org.fossasia.openevent.app.databinding.SpeakersCallCreateLayoutBinding;
@@ -24,7 +24,7 @@ import br.com.ilhasoft.support.validation.Validator;
 
 import static org.fossasia.openevent.app.ui.ViewUtils.showView;
 
-public class CreateSpeakersCallFragment extends BaseBottomSheetFragment implements CreateSpeakersCallView {
+public class CreateSpeakersCallFragment extends BaseFragment implements CreateSpeakersCallView {
 
     private static final String SPEAKERS_CALL_UPDATE = "speakers_update";
 
@@ -122,5 +122,19 @@ public class CreateSpeakersCallFragment extends BaseBottomSheetFragment implemen
     public void onSuccess(String message) {
         ViewUtils.showSnackbar(binding.getRoot(), message);
         dismiss();
+    }
+
+    @Override
+    protected int getTitle() {
+        if (isSpeakersCallUpdating) {
+            return R.string.update_speakers_call;
+        } else {
+            return R.string.create_speakers_call;
+        }
+    }
+
+    @Override
+    public void dismiss() {
+        getFragmentManager().popBackStack();
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/app/core/speakerscall/detail/SpeakersCallFragment.java
@@ -3,7 +3,6 @@ package org.fossasia.openevent.app.core.speakerscall.detail;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.design.widget.BottomSheetDialogFragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -58,10 +57,16 @@ public class SpeakersCallFragment extends BaseFragment<SpeakersCallPresenter> im
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.speakers_call_fragment, container, false);
         binding.createSpeakersCallFab.setOnClickListener(view -> {
-            BottomSheetDialogFragment bottomSheetDialogFragment = CreateSpeakersCallFragment.newInstance(eventId);
-            bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+            openCreateSpeakersCallFragment();
         });
         return binding.getRoot();
+    }
+
+    public void openCreateSpeakersCallFragment() {
+        getFragmentManager().beginTransaction()
+            .replace(R.id.fragment_container, CreateSpeakersCallFragment.newInstance(eventId))
+            .addToBackStack(null)
+            .commit();
     }
 
     @Override
@@ -99,8 +104,10 @@ public class SpeakersCallFragment extends BaseFragment<SpeakersCallPresenter> im
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.edit:
-                BottomSheetDialogFragment bottomSheetDialogFragment = CreateSpeakersCallFragment.newInstance(eventId, true);
-                bottomSheetDialogFragment.show(getFragmentManager(), bottomSheetDialogFragment.getTag());
+                getFragmentManager().beginTransaction()
+                    .replace(R.id.fragment_container, CreateSpeakersCallFragment.newInstance(eventId, true))
+                    .addToBackStack(null)
+                    .commit();
                 break;
             default:
                 // No implementation

--- a/app/src/main/res/layout/speakers_call_create_form.xml
+++ b/app/src/main/res/layout/speakers_call_create_form.xml
@@ -18,18 +18,6 @@
         android:orientation="vertical"
         android:paddingTop="@dimen/const_normal">
 
-        <TextView
-            style="@style/TextAppearance.AppCompat.Headline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginTop="@dimen/spacing_normal"
-            android:layout_marginBottom="@dimen/spacing_large"
-            android:layout_marginEnd="@dimen/spacing_large"
-            android:layout_marginRight="@dimen/spacing_large"
-            android:padding="@dimen/spacing_extra_small"
-            android:text="@string/create_speakers_call" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/speakers_call_create_layout.xml
+++ b/app/src/main/res/layout/speakers_call_create_layout.xml
@@ -13,7 +13,7 @@
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:background="@color/color_top_surface">
 
         <android.support.v4.widget.NestedScrollView
@@ -26,38 +26,26 @@
                 layout="@layout/speakers_call_create_form" />
         </android.support.v4.widget.NestedScrollView>
 
+        <Button
+            style="@style/SubmitButton"
+            android:id="@+id/submit"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/submit_button_width"
+            android:layout_gravity="bottom"
+            android:text="@string/done"/>
+
         <FrameLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top|end"
-            android:layout_marginRight="@dimen/spacing_normal"
-            android:layout_marginEnd="@dimen/spacing_normal"
-            android:layout_marginTop="@dimen/spacing_normal">
+            android:layout_width="@dimen/progressbar_large"
+            android:layout_height="@dimen/progressbar_large"
+            android:layout_gravity="center">
 
-            <android.support.design.widget.FloatingActionButton
-                android:id="@+id/submit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+            <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="center"
-                app:backgroundTint="@color/light_green_500"
-                app:fabSize="normal"
-                app:srcCompat="@drawable/ic_check"
-                app:tint="@android:color/white" />
-
-            <FrameLayout
-                android:layout_width="@dimen/progressbar_large"
-                android:layout_height="@dimen/progressbar_large"
-                android:layout_gravity="center">
-
-                <ProgressBar
-                    android:id="@+id/progressBar"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:theme="@style/AppTheme"
-                    android:visibility="gone" />
-
-            </FrameLayout>
+                android:theme="@style/AppTheme"
+                android:visibility="gone" />
 
         </FrameLayout>
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,7 @@
     <string name="date">Date</string>
     <string name="paidVia">Paid Via</string>
     <string name="payment_mode">Payment Mode</string>
+    <string name="update_speakers_call">Update Speakers Call</string>
 
     <string-array name="timezones">
         <item>Africa/Abidjan</item>


### PR DESCRIPTION
Fixes #1165 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: Converts CreateSpeakersCallFragment from BottomSheetFragment to proper fragment.

Screenshots for the change:

<img src="https://user-images.githubusercontent.com/35009811/42406721-bf3fe12a-81ca-11e8-99db-f7c4e8401641.png" width="250"/>