### PR TITLE
chore: Show end time in nav drawer and change title of account option

### DIFF
--- a/app/src/main/res/layout/main_nav_header.xml
+++ b/app/src/main/res/layout/main_nav_header.xml
@@ -87,7 +87,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:paletteText='@{ "event_header" }'
-                android:text='@{ event.startsAt != null ? DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_DATE_TIME, event.startsAt) : "" }'/>
+                android:text='@{ (event.startsAt != null &amp; event.endsAt != null) ? DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_DATE_TIME, event.getStartsAt()) + " - " + DateUtils.formatDateWithDefault(DateUtils.FORMAT_DAY_DATE_TIME, event.getEndsAt()) : "" }'/>
         </LinearLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -10,7 +10,7 @@
         <item
             android:id="@+id/nav_account"
             android:icon="@drawable/ic_account"
-            android:title="@string/my_account"
+            android:title="@string/account"
             android:checkable="false" />
     </group>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,7 +400,7 @@
     <string name="no_stay_safe">No, I want to stay safe</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
-    <string name="my_account">My Account</string>
+    <string name="account">Account</string>
     <string name="start_scanning_again">Start scanning again</string>
     <string name="play_sounds">Play sounds</string>
     <string name="play_sounds_key">play_sounds</string>


### PR DESCRIPTION
Fixes #1847 

Changes:

Now, event end date and time would also be shown in navigation drawer and changed `My Account` to `Account`.
