### PR TITLE
chore: Strip HTML tags from notifications

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/notification/list/NotificationsAdapter.java
+++ b/app/src/main/java/com/eventyay/organizer/core/notification/list/NotificationsAdapter.java
@@ -1,5 +1,6 @@
 package com.eventyay.organizer.core.notification.list;
 
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -33,6 +34,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter<NotificationsView
 
     @Override
     public void onBindViewHolder(@NonNull NotificationsViewHolder notificationsViewHolder, int position) {
+        notifications.get(position).setMessage(Html.fromHtml(notifications.get(position).getMessage()).toString());
         notificationsViewHolder.bind(notifications.get(position));
     }
 


### PR DESCRIPTION
Fixes #1868 

Changes: 

Now, HTML tags would not be present in notification messages.