### PR TITLE
chore: Bump version code and name for v1.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "com.eventyay.organizer"
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        versionCode 15
-        versionName "1.5.0"
+        versionCode 16
+        versionName "1.6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         manifestPlaceholders = [


### PR DESCRIPTION
Updated version code to `16` and version name to `1.6.0`.