### PR TITLE
fix: Use correct policy links and change Cookie Policy to Refund Policy

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/settings/LegalPreferenceFragment.java
+++ b/app/src/main/java/com/eventyay/organizer/core/settings/LegalPreferenceFragment.java
@@ -16,9 +16,9 @@ import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 public class LegalPreferenceFragment extends PreferenceFragmentCompat {
 
-    public static final String PRIVACY_POLICY_URL = "https://eventyay.com/privacy-policy/";
-    public static final String COOKIE_POLICY_URL = "https://eventyay.com/cookie-policy/";
-    public static final String TERMS_OF_USE_URL = "https://eventyay.com/terms/";
+    public static final String PRIVACY_POLICY_URL = "https://eventyay.com/privacy-policy";
+    public static final String REFUND_POLICY_URL = "https://eventyay.com/refunds";
+    public static final String TERMS_OF_USE_URL = "https://eventyay.com/terms";
 
     public static LegalPreferenceFragment newInstance() {
         return new LegalPreferenceFragment();
@@ -48,8 +48,8 @@ public class LegalPreferenceFragment extends PreferenceFragmentCompat {
             return true;
         });
 
-        findPreference(getString(R.string.cookie_policy_key)).setOnPreferenceClickListener(preference -> {
-            BrowserUtils.launchUrl(getContext(), COOKIE_POLICY_URL);
+        findPreference(getString(R.string.refund_policy_key)).setOnPreferenceClickListener(preference -> {
+            BrowserUtils.launchUrl(getContext(), REFUND_POLICY_URL);
             return true;
         });
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,10 +324,10 @@
     <string name="privacy_policy">Privacy Policy</string>
     <string name="app_version_key">app_version</string>
     <string name="legal">Legal</string>
-    <string name="cookie_policy_key">cookie_policy</string>
+    <string name="refund_policy_key">refund_policy</string>
     <string name="terms_of_service_key">terms_of_service</string>
     <string name="terms_of_service">Terms of Service</string>
-    <string name="cookie_policy">Cookie Policy</string>
+    <string name="refund_policy">Refund Policy</string>
     <string name="legal_key">legal_key</string>
     <string name="signup_agreement">By signing up, I agree to Eventyay\'s</string>
     <string name="and">and</string>

--- a/app/src/main/res/xml/legal_preferences.xml
+++ b/app/src/main/res/xml/legal_preferences.xml
@@ -10,7 +10,7 @@
         android:title="@string/terms_of_service" />
 
     <Preference
-        android:key="@string/cookie_policy_key"
-        android:title="@string/cookie_policy" />
+        android:key="@string/refund_policy_key"
+        android:title="@string/refund_policy" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #1890 

Changes:

- Used correct links for Privacy Policy and Terms of Service.
- Changed 'Cookie Policy' to 'Refund Policy'.
