### PR TITLE
fix: last name shows as "null"

### DIFF
--- a/app/src/main/res/layout/main_nav_header.xml
+++ b/app/src/main/res/layout/main_nav_header.xml
@@ -55,7 +55,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text='@{ user.firstName == null ? user.email : user.firstName + " " + user.lastName }'
+                    android:text='@{ user.firstName == null ? user.email : user.firstName + " " + (user.lastName == null ? "" : user.lastName) }'
                     android:textColor="@android:color/white"
                     android:textAppearance="@style/TextAppearance.AppCompat.Small.Inverse"
                     android:layout_marginTop="@dimen/spacing_normal"


### PR DESCRIPTION
Fixes #1939 

Changes: At the time of signup, the Last name field is optional, so if we don't fill this field then it shows the last name as null in navigation drawer as there was no check on the last name to be null. I have added a check on the user's last name to be "" if null otherwise the last name entered by the user.

Screenshots for the change:
![Screenshot_20191009-011540](https://user-images.githubusercontent.com/48120319/66427855-77c25680-ea32-11e9-89d8-e3e87c63ff70.png)


