### PR TITLE
fix: mutiple toast message on creating event

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
@@ -132,7 +132,6 @@ public class CreateEventViewModel extends ViewModel {
             onError.setValue("Please enter date in correct format");
             return false;
         }
-
     }
 
     protected void nullifyEmptyFields(Event event) {
@@ -168,14 +167,6 @@ public class CreateEventViewModel extends ViewModel {
 
     public LiveData<String> getErrorMessage() {
         return onError;
-    }
-
-    public void setErrorMessage(String s) {
-        onError.setValue(s);
-    }
-
-    public void setSuccessMessage(String s) {
-        onSuccess.setValue(s);
     }
 
     public LiveData<Void> getCloseState() {

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
@@ -132,6 +132,7 @@ public class CreateEventViewModel extends ViewModel {
             onError.setValue("Please enter date in correct format");
             return false;
         }
+
     }
 
     protected void nullifyEmptyFields(Event event) {

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/CreateEventViewModel.java
@@ -170,6 +170,14 @@ public class CreateEventViewModel extends ViewModel {
         return onError;
     }
 
+    public void setErrorMessage(String s) {
+        onError.setValue(s);
+    }
+
+    public void setSuccessMessage(String s) {
+        onSuccess.setValue(s);
+    }
+
     public LiveData<Void> getCloseState() {
         return close;
     }

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -134,7 +134,10 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void showError(String error) {
-        Toast.makeText(getActivity(), error, Toast.LENGTH_SHORT).show();
+        if(!error.equals("")) {
+            Toast.makeText(getActivity(), error, Toast.LENGTH_SHORT).show();
+            createEventViewModel.setErrorMessage("");
+        }
     }
 
     @Override
@@ -144,7 +147,10 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void onSuccess(String message) {
-        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+        if(!message.equals("")){
+            Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+            createEventViewModel.setSuccessMessage("");
+        }
     }
 
     public void close() {

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -69,6 +69,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
         createEventViewModel.getCloseState().observe(this, isClosed -> close());
         createEventViewModel.getProgress().observe(this, this::showProgress);
         createEventViewModel.getEvent().isTaxEnabled = true;
+
         createEventViewModel.getLogoUrlLiveData().observe(this, this::setLogoImageUrl);
         createEventViewModel.getImageUrlLiveData().observe(this, this::setOriginalImageUrl);
 

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -134,7 +134,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void showError(String error) {
-        if(!error.equals("")) {
+        if(!"".equals(error)) {
             Toast.makeText(getActivity(), error, Toast.LENGTH_SHORT).show();
             createEventViewModel.setErrorMessage("");
         }
@@ -147,7 +147,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void onSuccess(String message) {
-        if(!message.equals("")){
+        if(!"".equals(message)){
             Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
             createEventViewModel.setSuccessMessage("");
         }

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -57,6 +57,8 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
         binding = DataBindingUtil.inflate(inflater, R.layout.event_details_step_three, container, false);
         createEventViewModel = ViewModelProviders.of(getActivity(), viewModelFactory).get(CreateEventViewModel.class);
         validator = new Validator(binding);
+        createEventViewModel.getSuccessMessage().observe(this, this::onSuccess);
+        createEventViewModel.getErrorMessage().observe(this, this::showError);
         return binding.getRoot();
     }
 
@@ -64,12 +66,9 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     public void onStart() {
         super.onStart();
         binding.setEvent(createEventViewModel.getEvent());
-        createEventViewModel.getSuccessMessage().observe(this, this::onSuccess);
-        createEventViewModel.getErrorMessage().observe(this, this::showError);
         createEventViewModel.getCloseState().observe(this, isClosed -> close());
         createEventViewModel.getProgress().observe(this, this::showProgress);
         createEventViewModel.getEvent().isTaxEnabled = true;
-
         createEventViewModel.getLogoUrlLiveData().observe(this, this::setLogoImageUrl);
         createEventViewModel.getImageUrlLiveData().observe(this, this::setOriginalImageUrl);
 
@@ -134,10 +133,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void showError(String error) {
-        if(!error.equals("")) {
-            Toast.makeText(getActivity(), error, Toast.LENGTH_SHORT).show();
-            createEventViewModel.setErrorMessage("");
-        }
+        Toast.makeText(getActivity(), error, Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -147,10 +143,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
 
     @Override
     public void onSuccess(String message) {
-        if(!message.equals("")){
-            Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
-            createEventViewModel.setSuccessMessage("");
-        }
+        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
     }
 
     public void close() {


### PR DESCRIPTION
Fixes #1981 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
I made a function to empty the string after a toast message is displayed as the onError variable was not updated after removal of error and it was observed and displayed every time the activity started again. I also checked for empty messages and did not displayed them if they were null.
- [change 1](https://github.com/fossasia/open-event-organizer-android/compare/development...rishabh-997:develop?expand=1#diff-ef13da30f7163ed5cfe918e02b09ecb1)
- [change 2](https://github.com/fossasia/open-event-organizer-android/compare/development...rishabh-997:develop?expand=1#diff-ccd9f34b0b9f443f63acbf0a4e442e09)
