### PR TITLE
chore: Change strict mode penalty to dialog

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
+++ b/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
@@ -74,7 +74,7 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
 
             StrictMode.ThreadPolicy.Builder policyBuilder = new StrictMode.ThreadPolicy.Builder()
                 .detectAll()
-                .penaltyLog();
+                .penaltyDialog();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 /**

--- a/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
+++ b/app/src/main/java/com/eventyay/organizer/OrgaApplication.java
@@ -74,7 +74,7 @@ public class OrgaApplication extends MultiDexApplication implements HasActivityI
 
             StrictMode.ThreadPolicy.Builder policyBuilder = new StrictMode.ThreadPolicy.Builder()
                 .detectAll()
-                .penaltyDeath();
+                .penaltyLog();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 /**

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.StrictMode;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -49,8 +48,6 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     private static final int LOGO_IMAGE_CHOOSER_REQUEST_CODE = 1;
     private static final int ORIGINAL_IMAGE_CHOOSER_REQUEST_CODE = 2;
 
-    private StrictMode.ThreadPolicy defaultThreadPolicy;
-
     public static Fragment newInstance() {
         return new EventDetailsStepThree();
     }
@@ -69,9 +66,6 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     @Override
     public void onStart() {
         super.onStart();
-
-        defaultThreadPolicy = StrictMode.getThreadPolicy();
-        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().build());
 
         binding.setEvent(createEventViewModel.getEvent());
         createEventViewModel.getCloseState().observe(this, isClosed -> close());
@@ -156,7 +150,6 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     }
 
     public void close() {
-        StrictMode.setThreadPolicy(defaultThreadPolicy);
         getActivity().finish();
     }
 }

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.StrictMode;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,6 +49,8 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     private static final int LOGO_IMAGE_CHOOSER_REQUEST_CODE = 1;
     private static final int ORIGINAL_IMAGE_CHOOSER_REQUEST_CODE = 2;
 
+    private StrictMode.ThreadPolicy defaultThreadPolicy;
+
     public static Fragment newInstance() {
         return new EventDetailsStepThree();
     }
@@ -66,6 +69,10 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     @Override
     public void onStart() {
         super.onStart();
+
+        defaultThreadPolicy = StrictMode.getThreadPolicy();
+        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().build());
+
         binding.setEvent(createEventViewModel.getEvent());
         createEventViewModel.getCloseState().observe(this, isClosed -> close());
         createEventViewModel.getProgress().observe(this, this::showProgress);
@@ -149,6 +156,7 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     }
 
     public void close() {
+        StrictMode.setThreadPolicy(defaultThreadPolicy);
         getActivity().finish();
     }
 }

--- a/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
+++ b/app/src/main/java/com/eventyay/organizer/core/event/create/EventDetailsStepThree.java
@@ -66,7 +66,6 @@ public class EventDetailsStepThree extends BaseBottomSheetFragment implements Ev
     @Override
     public void onStart() {
         super.onStart();
-
         binding.setEvent(createEventViewModel.getEvent());
         createEventViewModel.getCloseState().observe(this, isClosed -> close());
         createEventViewModel.getProgress().observe(this, this::showProgress);


### PR DESCRIPTION
Fixes #2001 

Changes: 
Disabled StrictMode in the fragment which required to access the disk to upload graphics, and then re-enabled it once the fragment was killed.