### PR TITLE
fix: Entering Name in Edit Profile

### DIFF
--- a/app/src/main/res/layout/update_organizer_form.xml
+++ b/app/src/main/res/layout/update_organizer_form.xml
@@ -40,6 +40,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/name"
+                    android:singleLine="true"
                     android:text="@={ user.firstName }" />
 
             </com.google.android.material.textfield.TextInputLayout>
@@ -67,6 +68,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/family_name"
+                    android:singleLine="true"
                     android:text="@={ user.lastName }" />
 
             </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
Fixes #2048 Input Text field for name in Edit Profile

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
Made the Name and Family Name input to take single line in Input and pressing enter will take to next input text

Screenshots for the change:
![Screenshot_2020-01-25-02-15-57-207_com eventyay organizer](https://user-images.githubusercontent.com/44086235/73104256-098b9c00-3f1c-11ea-9ffc-bef7f6c8c937.jpg)

