### PR TITLE
fix: #2047 Mobile number max_length

### DIFF
--- a/app/src/main/res/layout/update_organizer_form.xml
+++ b/app/src/main/res/layout/update_organizer_form.xml
@@ -152,6 +152,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/phone"
+                    android:maxLength="10"
                     android:text="@={user.contact}"
                     android:inputType="number" />
 


### PR DESCRIPTION
Fixes #2047 No check for mobile number length

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
Mobile Number with max upto 10 digits can be entered by user

