### PR TITLE
fix: datetime input text alignment

### DIFF
--- a/app/src/main/res/layout/ends_at_time_picker.xml
+++ b/app/src/main/res/layout/ends_at_time_picker.xml
@@ -67,6 +67,7 @@
                 <com.google.android.material.textfield.TextInputEditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/spacing_zero"
                     android:hint="@{ label }"
                     android:inputType="datetime"
                     android:text="@={ date }"

--- a/app/src/main/res/layout/starts_at_time_picker.xml
+++ b/app/src/main/res/layout/starts_at_time_picker.xml
@@ -67,6 +67,7 @@
                 <com.google.android.material.textfield.TextInputEditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/spacing_zero"
                     android:hint="@{ label }"
                     android:inputType="datetime"
                     android:text="@={ date }"


### PR DESCRIPTION
Fix: dateTime inputText alignment issue #2055

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: No major changes, just added - paddingTop = 0dp in both the activities.

Screenshots for the change:
![Screenshot_20200127_175708_com eventyay organizer](https://user-images.githubusercontent.com/44394901/73175522-66f83680-4130-11ea-97ad-1cc667b75625.jpg)
