### PR TITLE
fix: crash when describe event left empty and back pressed (#2065)

### DIFF
--- a/app/src/main/java/com/eventyay/organizer/ui/editor/RichEditorActivity.java
+++ b/app/src/main/java/com/eventyay/organizer/ui/editor/RichEditorActivity.java
@@ -113,7 +113,7 @@ public class RichEditorActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (binding.editor.getHtml().equals(description)) {
+        if (binding.editor.getHtml() == null || binding.editor.getHtml().equals(description)) {
             saveChanges(description);
             return;
         }


### PR DESCRIPTION
Fixes #2065 

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.
