### PR TITLE
fix: Edit text hide behind Done button in landscape orientation

### DIFF
--- a/app/src/main/res/layout/update_organizer_form.xml
+++ b/app/src/main/res/layout/update_organizer_form.xml
@@ -15,6 +15,7 @@
         style="@style/ItemPadding"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="60dp"
         android:orientation="vertical"
         android:paddingTop="@dimen/const_normal">
 


### PR DESCRIPTION

i Fixes the issue #2122 

Made an proper Scrolling in Edit profile fragment in landscape orientation

Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes:  
in the parent Linear layout of   update_organizer_form.xml add the attribute  android:layout_marginBottom="60dp" 


GIF::
![20200626_112810](https://user-images.githubusercontent.com/65972015/85826091-7e038900-b7a1-11ea-8803-e74c3f6ccf82.gif)