### PR TITLE
Use of color code directly make the code difficult to read

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,4 +92,4 @@
             android:value="${MAPBOX_ACCESS_TOKEN}" />
     </application>
 
-</manifest
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,4 +92,4 @@
             android:value="${MAPBOX_ACCESS_TOKEN}" />
     </application>
 
-</manifest>
+</manifest

--- a/app/src/main/res/layout/organizer_detail_layout.xml
+++ b/app/src/main/res/layout/organizer_detail_layout.xml
@@ -71,7 +71,7 @@
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="#dedede"
+                        android:background="@color/gray87"
                         android:padding="@dimen/spacing_small"
                         android:text="@string/profile"
                         android:textAppearance="@style/TextAppearance.AppCompat.Headline"
@@ -175,7 +175,7 @@
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="#dedede"
+                        android:background="@color/gray87"
                         android:padding="@dimen/spacing_small"
                         android:text="@string/social_media_profiles"
                         android:textAppearance="@style/TextAppearance.AppCompat.Headline"

--- a/app/src/main/res/layout/update_organizer_form.xml
+++ b/app/src/main/res/layout/update_organizer_form.xml
@@ -154,6 +154,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/phone"
                     android:text="@={user.contact}"
+                    android:maxLength="10"
                     android:inputType="number" />
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,4 +28,6 @@
     <color name="tint_drawer_item_icon">#8C000000</color>
     <color name="color_drawer_item_text">#D9000000</color>
     <color name="event_state_draft">#FFF9C4</color>
+    <color name="gray87">#DEDEDE</color>
+
 </resources>


### PR DESCRIPTION
Fixes #[Use of color codes directly affect the readability of code and phone numbers max length must be 10]

